### PR TITLE
Custom properties on VConnections

### DIFF
--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -558,6 +558,7 @@ public:
   void addCustomProperty(const char *name, void *data, void (*f)(void*)) { customProperties.add(name,data,f); }
   void removeCustomProperty(const char *name) { customProperties.remove(name); }
   void* getCustomProperty(const char *name) { return customProperties.get(name); }
+  void removeAllCustomProperties() { customProperties.clear(); }
 private:
   CustomProperties customProperties;
 public:

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -29,6 +29,7 @@
 #include "I_Action.h"
 #include "I_VConnection.h"
 #include "I_Event.h"
+#include "ts/CustomProperty.h"
 #include "ts/List.h"
 #include "I_IOBuffer.h"
 #include "I_Socks.h"
@@ -553,6 +554,13 @@ public:
   {
     return netvc_context;
   }
+
+  void addCustomProperty(const char *name, void *data, void (*f)(void*)) { customProperties.add(name,data,f); }
+  void removeCustomProperty(const char *name) { customProperties.remove(name); }
+  void* getCustomProperty(const char *name) { return customProperties.get(name); }
+private:
+  CustomProperties customProperties;
+public:
 
   /** Structure holding user options. */
   NetVCOptions options;

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -953,6 +953,8 @@ SSLNetVConnection::free(EThread *t)
     connectResponse.reset();
   }
 
+  removeAllCustomProperties();
+
   if (from_accept_thread) {
     sslNetVCAllocator.free(this);
   } else {

--- a/lib/ts/CustomProperty.cc
+++ b/lib/ts/CustomProperty.cc
@@ -1,51 +1,27 @@
 #include "CustomProperty.h"
 
-CustomProperties::PropertyValue::PropertyValue(void *value, void(*destroyFunc)(void*))
-  : m_value(value), m_destroyFunc(destroyFunc)
+CustomProperties::CustomProperties()
+  : m_properties(new std::map<std::string, PropertyValue>())
 {
-}
-
-void CustomProperties::PropertyValue::destroy()
-{
-  if ((m_destroyFunc != nullptr) && (m_value != nullptr))
-  {
-    m_destroyFunc(m_value);
-    m_destroyFunc = nullptr;
-    m_value = nullptr;
-  }
-}
-
-CustomProperties::CustomProperties() 
-{
-    /**
-      Should not be necessary to dynamically allocate storage for
-      this map, but, if not dynamically allocated, then
-      insertions got segmentation faults:
-        Thread #4 [[ET_NET 1]] 28415 [core: 1] (Suspended : Signal : SIGSEGV:Segmentation fault)
-          std::_Rb_tree_decrement() at 0x3591869eca
-          std::_Rb_tree_iterator<std::pair<std::string const, CustomProperties::PropertyValue> >::operator--() at stl_tree.h:224 0x2b6f90fd7471
-          std::_Rb_tree<std::string, std::pair<std::string const, CustomProperties::PropertyValue>, std::_Select1st<std::pair<std::string const, CustomProperties::PropertyValue> >, std::less<std::string>, std::allocator<std::pair<std::string const, CustomProperties::PropertyValue> > >::_M_get_insert_unique_pos() at stl_tree.h:1,845 0x2b6f90fd6f97
-          std::_Rb_tree<std::string, std::pair<std::string const, CustomProperties::PropertyValue>, std::_Select1st<std::pair<std::string const, CustomProperties::PropertyValue> >, std::less<std::string>, std::allocator<std::pair<std::string const, CustomProperties::PropertyValue> > >::_M_insert_unique<std::pair<char const*, CustomProperties::PropertyValue> >() at stl_tree.h:1,889 0x2b6f90fd6b14
-          std::map<std::string, CustomProperties::PropertyValue, std::less<std::string>, std::allocator<std::pair<std::string const, CustomProperties::PropertyValue> > >::insert<std::pair<char const*, CustomProperties::PropertyValue>, void>() at stl_map.h:740 0x2b6f90fd68a8
-          CustomProperties::add() at CustomProperty.cc:36 0x2b6f90fd645b
-          NetVConnection::addCustomProperty() at I_NetVConnection.h:558 0x546978
-    */
-    m_properties = new std::map<std::string, PropertyValue>();
-}
-
-CustomProperties::~CustomProperties()
-{
-  for ( auto entry : *m_properties )
-  {
-    entry.second.destroy();
-  }
-  delete m_properties;
+  /**
+    Should not be necessary to dynamically allocate storage for
+    this map, but, if not dynamically allocated, then
+    insertions got segmentation faults:
+      Thread #4 [[ET_NET 1]] 28415 [core: 1] (Suspended : Signal : SIGSEGV:Segmentation fault)
+        std::_Rb_tree_decrement() at 0x3591869eca
+        std::_Rb_tree_iterator<std::pair<std::string const, CustomProperties::PropertyValue> >::operator--() at stl_tree.h:224 0x2b6f90fd7471
+        std::_Rb_tree<std::string, std::pair<std::string const, CustomProperties::PropertyValue>, std::_Select1st<std::pair<std::string const, CustomProperties::PropertyValue> >, std::less<std::string>, std::allocator<std::pair<std::string const, CustomProperties::PropertyValue> > >::_M_get_insert_unique_pos() at stl_tree.h:1,845 0x2b6f90fd6f97
+        std::_Rb_tree<std::string, std::pair<std::string const, CustomProperties::PropertyValue>, std::_Select1st<std::pair<std::string const, CustomProperties::PropertyValue> >, std::less<std::string>, std::allocator<std::pair<std::string const, CustomProperties::PropertyValue> > >::_M_insert_unique<std::pair<char const*, CustomProperties::PropertyValue> >() at stl_tree.h:1,889 0x2b6f90fd6b14
+        std::map<std::string, CustomProperties::PropertyValue, std::less<std::string>, std::allocator<std::pair<std::string const, CustomProperties::PropertyValue> > >::insert<std::pair<char const*, CustomProperties::PropertyValue>, void>() at stl_map.h:740 0x2b6f90fd68a8
+        CustomProperties::add() at CustomProperty.cc:36 0x2b6f90fd645b
+        NetVConnection::addCustomProperty() at I_NetVConnection.h:558 0x546978
+  */
 }
 
 void CustomProperties::add(const char *name, void *value, void(*destroyValue)(void*))
 {
   remove(name);
-  m_properties->insert(std::make_pair(name, PropertyValue(value, destroyValue)));
+  m_properties->emplace(std::make_pair(name, PropertyValue{value, destroyValue}));
 }
 
 void CustomProperties::remove(const char *name)
@@ -53,7 +29,6 @@ void CustomProperties::remove(const char *name)
   auto i = m_properties->find(name);
   if ( i != m_properties->end())
   {
-    i->second.destroy();
     m_properties->erase(i);
   }
 }
@@ -61,5 +36,10 @@ void CustomProperties::remove(const char *name)
 void* CustomProperties::get(const char *name)
 { 
   auto i = m_properties->find(name);
-  return i == m_properties->end() ? nullptr : i->second.m_value;
+  return i == m_properties->end() ? nullptr : i->second.get();
+}
+
+void CustomProperties::clear()
+{
+  m_properties->clear();
 }

--- a/lib/ts/CustomProperty.cc
+++ b/lib/ts/CustomProperty.cc
@@ -1,0 +1,65 @@
+#include "CustomProperty.h"
+
+CustomProperties::PropertyValue::PropertyValue(void *value, void(*destroyFunc)(void*))
+  : m_value(value), m_destroyFunc(destroyFunc)
+{
+}
+
+void CustomProperties::PropertyValue::destroy()
+{
+  if ((m_destroyFunc != nullptr) && (m_value != nullptr))
+  {
+    m_destroyFunc(m_value);
+    m_destroyFunc = nullptr;
+    m_value = nullptr;
+  }
+}
+
+CustomProperties::CustomProperties() 
+{
+    /**
+      Should not be necessary to dynamically allocate storage for
+      this map, but, if not dynamically allocated, then
+      insertions got segmentation faults:
+        Thread #4 [[ET_NET 1]] 28415 [core: 1] (Suspended : Signal : SIGSEGV:Segmentation fault)
+          std::_Rb_tree_decrement() at 0x3591869eca
+          std::_Rb_tree_iterator<std::pair<std::string const, CustomProperties::PropertyValue> >::operator--() at stl_tree.h:224 0x2b6f90fd7471
+          std::_Rb_tree<std::string, std::pair<std::string const, CustomProperties::PropertyValue>, std::_Select1st<std::pair<std::string const, CustomProperties::PropertyValue> >, std::less<std::string>, std::allocator<std::pair<std::string const, CustomProperties::PropertyValue> > >::_M_get_insert_unique_pos() at stl_tree.h:1,845 0x2b6f90fd6f97
+          std::_Rb_tree<std::string, std::pair<std::string const, CustomProperties::PropertyValue>, std::_Select1st<std::pair<std::string const, CustomProperties::PropertyValue> >, std::less<std::string>, std::allocator<std::pair<std::string const, CustomProperties::PropertyValue> > >::_M_insert_unique<std::pair<char const*, CustomProperties::PropertyValue> >() at stl_tree.h:1,889 0x2b6f90fd6b14
+          std::map<std::string, CustomProperties::PropertyValue, std::less<std::string>, std::allocator<std::pair<std::string const, CustomProperties::PropertyValue> > >::insert<std::pair<char const*, CustomProperties::PropertyValue>, void>() at stl_map.h:740 0x2b6f90fd68a8
+          CustomProperties::add() at CustomProperty.cc:36 0x2b6f90fd645b
+          NetVConnection::addCustomProperty() at I_NetVConnection.h:558 0x546978
+    */
+    m_properties = new std::map<std::string, PropertyValue>();
+}
+
+CustomProperties::~CustomProperties()
+{
+  for ( auto entry : *m_properties )
+  {
+    entry.second.destroy();
+  }
+  delete m_properties;
+}
+
+void CustomProperties::add(const char *name, void *value, void(*destroyValue)(void*))
+{
+  remove(name);
+  m_properties->insert(std::make_pair(name, PropertyValue(value, destroyValue)));
+}
+
+void CustomProperties::remove(const char *name)
+{
+  auto i = m_properties->find(name);
+  if ( i != m_properties->end())
+  {
+    i->second.destroy();
+    m_properties->erase(i);
+  }
+}
+
+void* CustomProperties::get(const char *name)
+{ 
+  auto i = m_properties->find(name);
+  return i == m_properties->end() ? nullptr : i->second.m_value;
+}

--- a/lib/ts/CustomProperty.h
+++ b/lib/ts/CustomProperty.h
@@ -1,6 +1,6 @@
 /** @file
 
-  A brief file description
+  A map for storing void* values keyed on a name string.
 
   @section license License
 
@@ -41,6 +41,7 @@
 #define CUSTOM_PROPERTY_H
 
 #include <map>
+#include <memory>
 #include <string>
 
 //
@@ -50,23 +51,17 @@ class CustomProperties
 {
 public:
   CustomProperties();
-  ~CustomProperties();
+  CustomProperties(const CustomProperties&) = delete;
+  CustomProperties operator=(const CustomProperties&) = delete;
   void add(const char *name, void *value, void(*destroyValue)(void*));
   void remove(const char *name);
   void* get(const char *name);
+  void clear();
 private:
-  CustomProperties(const CustomProperties&);
-  CustomProperties operator=(const CustomProperties&);
 
-  struct PropertyValue
-  {
-      PropertyValue(void *value = nullptr, void(*destroyFunc)(void*) = nullptr);
-      void *m_value;
-      void (*m_destroyFunc)(void*);
-      void destroy();
-  };
+  typedef std::unique_ptr<void, void(*)(void*)> PropertyValue;
 
-  std::map<std::string, PropertyValue>* m_properties;
+  std::unique_ptr<std::map<std::string, PropertyValue>> m_properties;
 };
 
 #endif

--- a/lib/ts/CustomProperty.h
+++ b/lib/ts/CustomProperty.h
@@ -1,0 +1,72 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+/****************************************************************************
+
+  CustomProperty.h
+
+  This file implements a simple map for storing property values keyed on a
+  name string.
+
+  The map assumes ownership of stored property values.
+
+  Because the value can be of any type (void*), storage of a value also
+  requires storage of a pointer to a function that the map can use in order
+  to destroy the value.
+
+  When the map is destroyed, remaining property values are destroyed.
+
+ ****************************************************************************/
+#ifndef CUSTOM_PROPERTY_H
+#define CUSTOM_PROPERTY_H
+
+#include <map>
+#include <string>
+
+//
+//    CustomProperties map
+//
+class CustomProperties
+{
+public:
+  CustomProperties();
+  ~CustomProperties();
+  void add(const char *name, void *value, void(*destroyValue)(void*));
+  void remove(const char *name);
+  void* get(const char *name);
+private:
+  CustomProperties(const CustomProperties&);
+  CustomProperties operator=(const CustomProperties&);
+
+  struct PropertyValue
+  {
+      PropertyValue(void *value = nullptr, void(*destroyFunc)(void*) = nullptr);
+      void *m_value;
+      void (*m_destroyFunc)(void*);
+      void destroy();
+  };
+
+  std::map<std::string, PropertyValue>* m_properties;
+};
+
+#endif

--- a/lib/ts/Makefile.am
+++ b/lib/ts/Makefile.am
@@ -23,7 +23,7 @@ library_includedir=$(includedir)/ts
 library_include_HEADERS = apidefs.h
 
 noinst_PROGRAMS = mkdfa CompileParseRules
-check_PROGRAMS = test_tsutil test_arena test_atomic test_freelist test_geometry test_List test_Map test_Vec test_X509HostnameValidator test_MemView test_tslib
+check_PROGRAMS = test_tsutil test_arena test_atomic test_freelist test_geometry test_CustomProperty test_List test_Map test_Vec test_X509HostnameValidator test_MemView test_tslib
 
 TESTS_ENVIRONMENT = LSAN_OPTIONS=suppressions=suppression.txt
 
@@ -56,6 +56,8 @@ libtsutil_la_SOURCES = \
   ConsistentHash.h \
   ContFlags.cc \
   ContFlags.h \
+  CustomProperty.cc \
+  CustomProperty.h \
   Diags.cc \
   Diags.h \
   SourceLocation.h \
@@ -216,6 +218,9 @@ test_freelist_LDADD = libtsutil.la @LIBTCL@ @LIBPCRE@
 
 test_arena_SOURCES = test_arena.cc
 test_arena_LDADD = libtsutil.la @LIBTCL@ @LIBPCRE@
+
+test_CustomProperty_SOURCES = test_CustomProperty.cc
+test_CustomProperty_LDADD = libtsutil.la @LIBTCL@ @LIBPCRE@
 
 test_List_SOURCES = test_List.cc
 test_Map_SOURCES = test_Map.cc

--- a/lib/ts/apidefs.h.in
+++ b/lib/ts/apidefs.h.in
@@ -856,6 +856,7 @@ typedef struct tsapi_protocol_set *TSNextProtocolSet;
 typedef void *(*TSThreadFunc)(void *data);
 typedef int (*TSEventFunc)(TSCont contp, TSEvent event, void *edata);
 typedef void (*TSConfigDestroyFunc)(void *data);
+typedef void (*TSCustomPropertyDestroyFunc)(void *data);
 
 typedef struct {
   int success_event_id;

--- a/lib/ts/test_CustomProperty.cc
+++ b/lib/ts/test_CustomProperty.cc
@@ -1,0 +1,119 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "ts/CustomProperty.h"
+
+void intDelete(void*f)
+{
+  delete (int*)f;
+}
+
+class MyValue
+{
+public:
+  MyValue(char c = '\0') : m_c(c) {}
+  ~MyValue() {}
+  bool operator==(const MyValue& other) { return this->m_c == other.m_c; }
+  bool operator!=(const MyValue& other) { return !( *this == other);     }
+  static int constructed;
+  static int destroyed;
+private:
+  char m_c;
+  MyValue(const MyValue&);
+  MyValue& operator=(const MyValue&);
+};
+
+
+int destroyedByMap = 0;
+
+
+void resetCounts() { 
+  destroyedByMap = 0;
+}
+
+void destroyMyValue(void* mv) { 
+  if (mv != nullptr) {
+    delete static_cast<MyValue*>(mv); 
+    destroyedByMap++;
+  }
+}
+
+void verify(bool condition, const char* errorMsg = "") { 
+  if (!condition) { 
+    printf("test_CustomProperty FAILED: %s\n", errorMsg); 
+    exit(1); 
+  }   
+}
+
+int
+main() 
+{
+  // Test expectations for addition and retrieval
+  {
+    CustomProperties cp;
+    cp.add("a", new MyValue('a'), destroyMyValue);
+    cp.add("b", new MyValue('b'), destroyMyValue);
+    cp.add("a", new MyValue('x'), destroyMyValue);
+    verify( cp.get("a") != nullptr );
+    verify( cp.get("b") != nullptr );
+    verify( cp.get("c") == nullptr );
+    verify( (*static_cast<MyValue*>(cp.get("a"))) == MyValue('x'));
+    verify( (*static_cast<MyValue*>(cp.get("b"))) == MyValue('b'));
+    verify( (*static_cast<MyValue*>(cp.get("b"))) != MyValue('c'));
+    verify(destroyedByMap == 1,"Expect deletion for repeated insertion using same key");
+  }
+
+  resetCounts();
+
+  // Test expectations for destruction
+  {
+    CustomProperties cp;
+    cp.add("a", new MyValue(), destroyMyValue);
+    cp.add("b", new MyValue(), destroyMyValue);
+    cp.add("c", new MyValue(), destroyMyValue);
+    verify(destroyedByMap == 0);
+  }
+
+  verify(destroyedByMap == 3);
+
+  resetCounts();
+
+  // Test expectations for value removal
+  {
+    CustomProperties cp;
+    cp.add("a", new MyValue('a'), destroyMyValue);
+    cp.add("b", new MyValue('b'), destroyMyValue);
+    cp.add("c", new MyValue('c'), destroyMyValue);
+    cp.remove("a");
+    cp.remove("a");
+    cp.remove("b");
+    verify(destroyedByMap == 2);
+  }
+
+  verify(destroyedByMap == 3);
+
+  printf("test_CustomProperty PASSED\n");
+
+  exit(0);
+}
+

--- a/lib/ts/test_CustomProperty.cc
+++ b/lib/ts/test_CustomProperty.cc
@@ -1,6 +1,6 @@
 /** @file
 
-  A brief file description
+  Unit tests for class CustomProperties (defined in CustomProperty.h).
 
   @section license License
 
@@ -66,7 +66,7 @@ void verify(bool condition, const char* errorMsg = "") {
 }
 
 int
-main() 
+main()
 {
   // Test expectations for addition and retrieval
   {
@@ -111,6 +111,18 @@ main()
   }
 
   verify(destroyedByMap == 3);
+
+  resetCounts();
+
+  // Test clearance
+  {
+    CustomProperties cp;
+    cp.add("a", new MyValue('a'), destroyMyValue);
+    cp.add("b", new MyValue('b'), destroyMyValue);
+    cp.add("c", new MyValue('c'), destroyMyValue);
+    cp.clear();
+    verify(destroyedByMap == 3);
+  }
 
   printf("test_CustomProperty PASSED\n");
 

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -9634,3 +9634,41 @@ TSVConn TSHttpTxnOutgoingVConn(TSHttpTxn txnp)
   return reinterpret_cast<TSVConn>(vc);
 }
 
+void TSCustomPropertyAdd(TSVConn connp, const char *name, void *data, TSCustomPropertyDestroyFunc funcp)
+{
+  sdk_assert(sdk_sanity_check_iocore_structure(connp) == TS_SUCCESS);
+
+  NetVConnection *vc = (NetVConnection *)connp;
+
+  if (vc != nullptr)
+  {
+    vc->addCustomProperty(name, data, funcp);
+  }
+}
+
+void TSCustomPropertyRemove(TSVConn connp, const char *name)
+{
+  sdk_assert(sdk_sanity_check_iocore_structure(connp) == TS_SUCCESS);
+
+  NetVConnection *vc = (NetVConnection *)connp;
+
+  if (vc != nullptr)
+  {
+    vc->removeCustomProperty(name);
+  }
+}
+
+void* TSCustomPropertyGet(TSVConn connp, const char *name)
+{
+  void *p = 0;
+  sdk_assert(sdk_sanity_check_iocore_structure(connp) == TS_SUCCESS);
+
+  NetVConnection *vc = (NetVConnection *)connp;
+
+  if (vc != nullptr)
+  {
+    p = vc->getCustomProperty(name);
+  }
+
+  return p;
+}

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -9634,7 +9634,7 @@ TSVConn TSHttpTxnOutgoingVConn(TSHttpTxn txnp)
   return reinterpret_cast<TSVConn>(vc);
 }
 
-void TSCustomPropertyAdd(TSVConn connp, const char *name, void *data, TSCustomPropertyDestroyFunc funcp)
+void TSVConnCustomPropertyAdd(TSVConn connp, const char *name, void *data, TSCustomPropertyDestroyFunc funcp)
 {
   sdk_assert(sdk_sanity_check_iocore_structure(connp) == TS_SUCCESS);
 
@@ -9646,7 +9646,7 @@ void TSCustomPropertyAdd(TSVConn connp, const char *name, void *data, TSCustomPr
   }
 }
 
-void TSCustomPropertyRemove(TSVConn connp, const char *name)
+void TSVConnCustomPropertyRemove(TSVConn connp, const char *name)
 {
   sdk_assert(sdk_sanity_check_iocore_structure(connp) == TS_SUCCESS);
 
@@ -9658,7 +9658,7 @@ void TSCustomPropertyRemove(TSVConn connp, const char *name)
   }
 }
 
-void* TSCustomPropertyGet(TSVConn connp, const char *name)
+void* TSVConnCustomPropertyGet(TSVConn connp, const char *name)
 {
   void *p = 0;
   sdk_assert(sdk_sanity_check_iocore_structure(connp) == TS_SUCCESS);

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -6083,6 +6083,15 @@ TSHttpTxnServerStateGet(TSHttpTxn txnp)
 }
 
 void
+TSHttpTxnServerStateSet(TSHttpTxn txnp, TSServerState state)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+
+  HttpTransact::State *s = &(((HttpSM *)txnp)->t_state);
+  s->current.state = (HttpTransact::ServerState_t)state;
+}
+
+void
 TSHttpTxnDebugSet(TSHttpTxn txnp, int on)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -9598,3 +9598,10 @@ void TSVConnConnectResponseBodySet(TSVConn vconn, const char *body, int64_t leng
 
     ssl_vc->setConnectResponseBody(const_cast<char *>(body), length);
 }
+
+TSVConn TSGetVConnFromSsl(TSSslConnection sslConnection)
+{
+  SSL* ssl = reinterpret_cast<SSL*>(sslConnection);
+  return ssl == nullptr ? nullptr : reinterpret_cast<TSVConn>(SSLNetVCAccess(ssl));
+}
+

--- a/proxy/InkAPI.cc
+++ b/proxy/InkAPI.cc
@@ -9605,3 +9605,23 @@ TSVConn TSGetVConnFromSsl(TSSslConnection sslConnection)
   return ssl == nullptr ? nullptr : reinterpret_cast<TSVConn>(SSLNetVCAccess(ssl));
 }
 
+TSVConn TSHttpTxnOutgoingVConn(TSHttpTxn txnp)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+
+  NetVConnection *vc = nullptr;
+
+  HttpSM *sm = reinterpret_cast<HttpSM *>(txnp);
+
+  if (sm != nullptr)
+  {
+    HttpServerSession *ssn = sm->get_server_session();
+    if (ssn != nullptr)
+    {
+      vc = ssn->get_netvc();
+    }
+  }
+
+  return reinterpret_cast<TSVConn>(vc);
+}
+

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1543,6 +1543,7 @@ tsapi void TSHttpTxnDNSTimeoutSet(TSHttpTxn txnp, int timeout);
 tsapi void TSHttpTxnNoActivityTimeoutSet(TSHttpTxn txnp, int timeout);
 
 tsapi TSServerState TSHttpTxnServerStateGet(TSHttpTxn txnp);
+tsapi void TSHttpTxnServerStateSet(TSHttpTxn txnp, TSServerState s);
 
 /* --------------------------------------------------------------------------
    Transaction specific debugging control  */

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1187,9 +1187,9 @@ tsapi TSConfig TSConfigGet(unsigned int id);
 tsapi void TSConfigRelease(unsigned int id, TSConfig configp);
 tsapi void *TSConfigDataGet(TSConfig configp);
 
-tsapi void TSCustomPropertyAdd(TSVConn connp, const char *name, void *data, TSCustomPropertyDestroyFunc funcp);
-tsapi void TSCustomPropertyRemove(TSVConn connp, const char *name);
-tsapi void *TSCustomPropertyGet(TSVConn connp, const char *name);
+tsapi void TSVConnCustomPropertyAdd(TSVConn connp, const char *name, void *data, TSCustomPropertyDestroyFunc funcp);
+tsapi void TSVConnCustomPropertyRemove(TSVConn connp, const char *name);
+tsapi void *TSVConnCustomPropertyGet(TSVConn connp, const char *name);
 
 /* --------------------------------------------------------------------------
    Management */

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1187,6 +1187,10 @@ tsapi TSConfig TSConfigGet(unsigned int id);
 tsapi void TSConfigRelease(unsigned int id, TSConfig configp);
 tsapi void *TSConfigDataGet(TSConfig configp);
 
+tsapi void TSCustomPropertyAdd(TSVConn connp, const char *name, void *data, TSCustomPropertyDestroyFunc funcp);
+tsapi void TSCustomPropertyRemove(TSVConn connp, const char *name);
+tsapi void *TSCustomPropertyGet(TSVConn connp, const char *name);
+
 /* --------------------------------------------------------------------------
    Management */
 tsapi void TSMgmtUpdateRegister(TSCont contp, const char *plugin_name);

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1246,6 +1246,9 @@ int TSAcceptorIDGet(TSAcceptor acceptor);
 // Returns 1 if the sslp argument refers to a SSL connection
 tsapi int TSVConnIsSsl(TSVConn sslp);
 
+/* Get the VConn associated with the specified SSL connection.  */
+tsapi TSVConn TSGetVConnFromSsl(TSSslConnection sslConnection);
+
 /* --------------------------------------------------------------------------
    HTTP transactions */
 tsapi void TSHttpTxnHookAdd(TSHttpTxn txnp, TSHttpHookID id, TSCont contp);

--- a/proxy/api/ts/ts.h
+++ b/proxy/api/ts/ts.h
@@ -1318,6 +1318,9 @@ tsapi void TSHttpTxnClientIncomingPortSet(TSHttpTxn txnp, int port);
  */
 tsapi void *TSHttpSsnSSLConnectionGet(TSHttpSsn ssnp); // returns SSL *
 
+/** Get the outgoing VConn for the specified transaction. */
+tsapi TSVConn TSHttpTxnOutgoingVConn(TSHttpTxn txnp);
+
 /** Get client address for transaction @a txnp.
     Retrieves the socket address of the remote client that has
     connected to Traffic Server for transaction @a txnp. The


### PR DESCRIPTION
The specific use-case addressed by these changes is the need to implement bespoke verification of the origin server certificate and enable a plugin to return a page descriptive of verification errors in the case when verification fails.

In more detail:

If an OpenSSL verification callback can obtain the VConnection, then, in the event of verification failures, the callback can add properties to the VConnection to describe the failures.  A plugin can subsequently retrieve this description and use it to add extra content to the HTTP response.
